### PR TITLE
修复了子模块clone和checkout的bug

### DIFF
--- a/src/executor/source.rs
+++ b/src/executor/source.rs
@@ -204,7 +204,7 @@ impl GitSource {
                 cmd_str+=revision;
                 cmd_str+=" ";
             }
-            
+
             // 强制切换分支，且安静模式
             cmd.arg("-f").arg("-q");
             cmd_str+=" -f -q ";
@@ -217,7 +217,6 @@ impl GitSource {
             bash.current_dir(&target_dir.path);
             bash.arg("-c").arg(cmd_str);
 
-            
             // 创建子进程，执行命令
             let proc: std::process::Child = bash
                 .stderr(Stdio::piped())
@@ -282,11 +281,11 @@ impl GitSource {
         let output = proc.wait_with_output().map_err(|e| e.to_string())?;
 
         if !output.status.success() {
-                return Err(format!(
-                    "clone git repo failed, status: {:?},  stderr: {:?}",
-                    output.status,
-                    StdioUtils::tail_n_str(StdioUtils::stderr_to_lines(&output.stderr), 5)
-                ));
+            return Err(format!(
+                "clone git repo failed, status: {:?},  stderr: {:?}",
+                output.status,
+                StdioUtils::tail_n_str(StdioUtils::stderr_to_lines(&output.stderr), 5)
+            ));
         }
         return Ok(());
     }

--- a/src/executor/source.rs
+++ b/src/executor/source.rs
@@ -219,7 +219,7 @@ impl GitSource {
                 ));
             }
 
-            //当checkout仓库的子进程结束后，启动子模块的子进程
+            //当checkout仓库的子进程结束后，启动checkout子模块的子进程
             let subproc: std::process::Child = subcmd
                 .stderr(Stdio::piped())
                 .spawn()
@@ -289,7 +289,7 @@ impl GitSource {
             ));
         }
 
-        //当克隆仓库的子进程结束后，启动子模块的子进程
+        //当克隆仓库的子进程结束后，启动保证克隆子模块的子进程
         let subproc: std::process::Child = subcmd
             .stderr(Stdio::piped())
             .stdout(Stdio::inherit())

--- a/src/executor/source.rs
+++ b/src/executor/source.rs
@@ -219,6 +219,7 @@ impl GitSource {
                 ));
             }
 
+            //当克隆仓库的子进程结束后，启动子模块的子进程
             let subproc: std::process::Child = subcmd
                 .stderr(Stdio::piped())
                 .spawn()
@@ -288,6 +289,7 @@ impl GitSource {
             ));
         }
 
+        //当克隆仓库的子进程结束后，启动子模块的子进程
         let subproc: std::process::Child = subcmd
             .stderr(Stdio::piped())
             .stdout(Stdio::inherit())

--- a/src/executor/source.rs
+++ b/src/executor/source.rs
@@ -219,7 +219,7 @@ impl GitSource {
                 ));
             }
 
-            //当克隆仓库的子进程结束后，启动子模块的子进程
+            //当checkout仓库的子进程结束后，启动子模块的子进程
             let subproc: std::process::Child = subcmd
                 .stderr(Stdio::piped())
                 .spawn()

--- a/src/executor/source.rs
+++ b/src/executor/source.rs
@@ -174,7 +174,7 @@ impl GitSource {
         Ok(())
     }
 
-     fn checkout(&self, target_dir: &CacheDir) -> Result<(), String> {
+    fn checkout(&self, target_dir: &CacheDir) -> Result<(), String> {
         // 确保目标目录中的仓库为所指定仓库
         if !self.check_repo(target_dir).map_err(|e| {
             format!(


### PR DESCRIPTION
1.仓库克隆时，不管第一次运行子模块有没有被完整克隆，都强制克隆一次子模块。
2.仓库checkout的时候对子模块一并进行checkout。