### PR TITLE
feat: Add dadk-manifest

### DIFF
--- a/dadk-config/Cargo.toml
+++ b/dadk-config/Cargo.toml
@@ -9,3 +9,11 @@ authors = [
 ]
 
 [dependencies]
+anyhow = { version = "1.0.90", features = ["std", "backtrace"] }
+serde = { version = "1.0.160", features = ["serde_derive"] }
+serde_json = "1.0.96"
+toml = "0.8.12"
+
+# 只有在test的情况下才会引入下列库
+[dev-dependencies]
+tempfile = "3.13.0"

--- a/dadk-config/src/common/mod.rs
+++ b/dadk-config/src/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod target_arch;

--- a/dadk-config/src/common/target_arch.rs
+++ b/dadk-config/src/common/target_arch.rs
@@ -1,0 +1,75 @@
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// 目标处理器架构
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetArch {
+    X86_64,
+    RiscV64,
+}
+
+impl TargetArch {
+    /// 期望的目标处理器架构（如果修改了枚举，那一定要修改这里）
+    pub const EXPECTED: [&'static str; 2] = ["x86_64", "riscv64"];
+}
+
+impl Default for TargetArch {
+    fn default() -> Self {
+        TargetArch::X86_64
+    }
+}
+
+impl TryFrom<&str> for TargetArch {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "x86_64" => Ok(TargetArch::X86_64),
+            "riscv64" => Ok(TargetArch::RiscV64),
+            _ => Err(format!("Unknown target arch: {}", value)),
+        }
+    }
+}
+
+impl Into<&str> for TargetArch {
+    fn into(self) -> &'static str {
+        match self {
+            TargetArch::X86_64 => "x86_64",
+            TargetArch::RiscV64 => "riscv64",
+        }
+    }
+}
+
+impl Into<String> for TargetArch {
+    fn into(self) -> String {
+        let x: &str = self.into();
+        x.to_string()
+    }
+}
+
+impl<'de> Deserialize<'de> for TargetArch {
+    fn deserialize<D>(deserializer: D) -> Result<TargetArch, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        let r = TargetArch::try_from(s.as_str());
+        match r {
+            Ok(v) => Ok(v),
+            Err(_) => Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(s.as_str()),
+                &format!("Expected one of {:?}", TargetArch::EXPECTED).as_str(),
+            )),
+        }
+    }
+}
+
+impl Serialize for TargetArch {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let string: String = Into::into(*self);
+        serializer.serialize_str(string.as_str())
+    }
+}

--- a/dadk-config/src/lib.rs
+++ b/dadk-config/src/lib.rs
@@ -1,1 +1,5 @@
+mod common;
+pub mod manifest;
 pub mod user;
+
+extern crate anyhow;

--- a/dadk-config/src/manifest.rs
+++ b/dadk-config/src/manifest.rs
@@ -1,0 +1,123 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::common::target_arch::TargetArch;
+
+use std::fs;
+use toml;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Metadata {
+    /// Target processor architecture
+    pub arch: TargetArch,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DadkManifest {
+    pub metadata: Metadata,
+}
+
+impl DadkManifest {
+    pub fn load(path: &PathBuf) -> Result<Self> {
+        // 读取文件内容
+        let content = fs::read_to_string(path)?;
+        Self::do_load(&content)
+    }
+
+    fn do_load(content: &str) -> Result<Self> {
+        // 解析TOML内容
+        let manifest_toml: DadkManifest = toml::from_str(&content)?;
+
+        Ok(manifest_toml)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_load_success() -> Result<()> {
+        let toml_content = r#"
+            [metadata]
+            arch = "x86_64"
+        "#;
+
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(toml_content.as_bytes())?;
+
+        let path = temp_file.path().to_path_buf();
+        let manifest = DadkManifest::load(&path)?;
+
+        assert_eq!(manifest.metadata.arch, TargetArch::X86_64);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_file_not_found() {
+        let path = PathBuf::from("non_existent_file.toml");
+        let result = DadkManifest::load(&path);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_load_invalid_toml() -> Result<()> {
+        let invalid_toml_content = r#"
+            [metadata
+            arch = "x86_64"
+        "#;
+
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(invalid_toml_content.as_bytes())?;
+
+        let path = temp_file.path().to_path_buf();
+        let result = DadkManifest::load(&path);
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_invalid_arch_toml() -> Result<()> {
+        // Invalid arch value
+        let invalid_toml_content = r#"
+            [metadata]
+            arch = "abcde"
+        "#;
+
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(invalid_toml_content.as_bytes())?;
+
+        let path = temp_file.path().to_path_buf();
+        let result = DadkManifest::load(&path);
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_missing_required_fields() -> Result<()> {
+        let toml_content = r#"
+            [metadata]
+            # arch field is missing
+        "#;
+
+        let mut temp_file = NamedTempFile::new()?;
+        temp_file.write_all(toml_content.as_bytes())?;
+
+        let path = temp_file.path().to_path_buf();
+        let result = DadkManifest::load(&path);
+
+        assert!(result.is_err());
+
+        Ok(())
+    }
+}

--- a/dadk-config/templates/dadk-manifest.toml
+++ b/dadk-config/templates/dadk-manifest.toml
@@ -1,0 +1,6 @@
+# Configuration template placed in the root directory of the DragonOS workspace
+# Named `dadk-manifest.toml`
+
+[metadata]
+# Target architecture. Options: x86_64, riscv64
+target_arch = "x86_64"

--- a/dadk/Cargo.toml
+++ b/dadk/Cargo.toml
@@ -21,6 +21,7 @@ doc = true
 
 
 [dependencies]
+anyhow = { version = "1.0.90", features = ["std", "backtrace"] }
 dadk-user = { path = "../dadk-user" }
 env_logger = "0.11.5"
 log = "0.4.22"

--- a/dadk/src/lib.rs
+++ b/dadk/src/lib.rs
@@ -1,5 +1,7 @@
 use dadk_user::dadk_user_main;
 
+extern crate anyhow;
+
 pub fn dadk_main() {
     dadk_user_main();
 }


### PR DESCRIPTION
添加dadk-manifest的支持

dadk-manifest.toml是放置在DragonOS工作区根目录下的配置文件。用户根据模版生成该配置文件。配置文件里面要指定：
- target arch
- 顶层的用户程序清单路径
- （可选）内核编译配置文件
- （可选）系统打包、运行配置文件

将来实现：dadk提供模版，然后用户可以根据默认模版一键配置好。同时也能自定义字段值。