### PR TITLE
fix: 修复挂载loop设备之后,内核数据未同步导致的问题

### DIFF
--- a/dadk/src/actions/rootfs/loopdev.rs
+++ b/dadk/src/actions/rootfs/loopdev.rs
@@ -1,5 +1,5 @@
 use core::str;
-use std::{path::PathBuf, process::Command};
+use std::{path::PathBuf, process::Command, thread::sleep, time::Duration};
 
 use anyhow::{anyhow, Result};
 use regex::Regex;
@@ -39,6 +39,7 @@ impl LoopDevice {
         if output.status.success() {
             let loop_device = String::from_utf8(output.stdout)?.trim().to_string();
             self.loop_device_path = Some(loop_device);
+            sleep(Duration::from_millis(100));
             log::trace!(
                 "Loop device attached: {}",
                 self.loop_device_path.as_ref().unwrap()


### PR DESCRIPTION
需要sleep一段时间等待lsblk数据同步