### PR TITLE
feat: 添加一些rootfs命令

### DIFF
--- a/dadk/src/actions/rootfs/mod.rs
+++ b/dadk/src/actions/rootfs/mod.rs
@@ -7,10 +7,13 @@ mod sysroot;
 
 pub(super) fn run(ctx: &DADKExecContext, rootfs_cmd: &RootFSCommand) -> Result<()> {
     match rootfs_cmd {
-        RootFSCommand::Create => disk_img::create(ctx, false),
+        RootFSCommand::Create(param) => disk_img::create(ctx, param.skip_if_exists),
         RootFSCommand::Delete => disk_img::delete(ctx, false),
         RootFSCommand::DeleteSysroot => sysroot::delete(ctx),
         RootFSCommand::Mount => disk_img::mount(ctx),
         RootFSCommand::Umount => disk_img::umount(ctx),
+        RootFSCommand::CheckDiskImageExists => disk_img::check_disk_image_exists(ctx),
+        RootFSCommand::ShowMountPoint => disk_img::show_mount_point(ctx),
+        RootFSCommand::ShowLoopDevice => disk_img::show_loop_device(ctx),
     }
 }

--- a/dadk/src/console/rootfs.rs
+++ b/dadk/src/console/rootfs.rs
@@ -1,10 +1,10 @@
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 
 // 定义一个枚举类型 RootFSCommand，表示根文件系统操作命令
-#[derive(Debug, Parser, Clone, PartialEq, Eq, ValueEnum)]
+#[derive(Debug, Parser, Clone, PartialEq, Eq)]
 pub enum RootFSCommand {
     /// 创建根文件系统（磁盘镜像）
-    Create,
+    Create(CreateCommandParam),
     /// 删除根文件系统（磁盘镜像）
     Delete,
     /// 删除系统根目录（sysroot文件夹）
@@ -13,4 +13,18 @@ pub enum RootFSCommand {
     Mount,
     /// 卸载根文件系统（磁盘镜像）
     Umount,
+    /// 输出磁盘镜像的挂载点
+    #[clap(name = "show-mountpoint")]
+    ShowMountPoint,
+    /// 输出磁盘镜像挂载到的loop设备
+    ShowLoopDevice,
+    /// 检查磁盘镜像文件是否存在
+    CheckDiskImageExists,
+}
+
+#[derive(Debug, Parser, Clone, PartialEq, Eq)]
+pub struct CreateCommandParam {
+    /// 当磁盘镜像文件存在时，跳过创建
+    #[clap(long = "skip-if-exists", default_value = "false")]
+    pub skip_if_exists: bool,
 }

--- a/dadk/src/console/tests.rs
+++ b/dadk/src/console/tests.rs
@@ -1,3 +1,4 @@
+use rootfs::CreateCommandParam;
 use user::UserCleanLevel;
 
 use super::*;
@@ -25,7 +26,29 @@ fn test_command_line_args_with_manifest() {
 #[test]
 fn test_command_line_args_rootfs_subcommand() {
     let args = CommandLineArgs::parse_from(&["dadk", "rootfs", "create"]);
-    assert!(matches!(args.action, Action::Rootfs(RootFSCommand::Create)));
+    assert!(matches!(
+        args.action,
+        Action::Rootfs(RootFSCommand::Create(CreateCommandParam {
+            skip_if_exists: false
+        }))
+    ));
+
+    let args = CommandLineArgs::parse_from(&["dadk", "rootfs", "create", "--skip-if-exists"]);
+    assert!(matches!(
+        args.action,
+        Action::Rootfs(RootFSCommand::Create(CreateCommandParam {
+            skip_if_exists: true
+        }))
+    ));
+}
+
+#[test]
+fn test_show_mountpoint() {
+    let args = CommandLineArgs::parse_from(&["dadk", "rootfs", "show-mountpoint"]);
+    assert!(matches!(
+        args.action,
+        Action::Rootfs(RootFSCommand::ShowMountPoint)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
添加了:
- rootfs create: 添加 `--skip-if-exists`参数,允许当磁盘镜像存在时跳过创建
- rootfs show-mountpoint: 添加该命令,用于获取磁盘挂载点
- rootfs show-loopdevice: 添加该命令,用于获取磁盘镜像被挂载到的磁盘镜像的路径
- rootfs check-disk-image-exists: 用于检查磁盘镜像是否存在