### PR TITLE
Fix task log parsing error handling and bump to v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "dadk"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "dadk-config"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "dadk-user"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ DADK是一个Rust程序，您可以通过Cargo来安装DADK。
 cargo install --git https://github.com/DragonOS-Community/DADK.git
 
 # 或安装指定版本（推荐与DragonOS分支匹配）
-cargo install --git https://git.mirrors.dragonos.org.cn/DragonOS-Community/DADK.git --tag v0.6.0 --locked
+cargo install --git https://git.mirrors.dragonos.org.cn/DragonOS-Community/DADK.git --tag v0.6.1 --locked
 
 
 ```

--- a/dadk-config/Cargo.toml
+++ b/dadk-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dadk-config"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = [
     "longjin <longjin@DragonOS.org>",

--- a/dadk-user/Cargo.toml
+++ b/dadk-user/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dadk-user"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "DragonOS Application Development Kit - user prog build"
 license = "GPL-2.0-only"
@@ -9,7 +9,7 @@ license = "GPL-2.0-only"
 anyhow = { version = "1.0.100", features = ["std", "backtrace"] }
 chrono = { version = "=0.4.35", features = ["serde"] }
 clap = { version = "=4.5.20", features = ["derive"] }
-dadk-config = { version = "0.6.0", path = "../dadk-config" }
+dadk-config = { version = "0.6.1", path = "../dadk-config" }
 derive_builder = "0.20.0"
 lazy_static = "1.4.0"
 log = "0.4.17"

--- a/dadk-user/src/parser/task_log.rs
+++ b/dadk-user/src/parser/task_log.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 pub struct TaskLog {
     /// 任务执行完成时间
     #[serde(
+        default,
         deserialize_with = "ok_or_default",
         skip_serializing_if = "Option::is_none"
     )]
@@ -148,5 +149,17 @@ impl<'de> Deserialize<'de> for InstallStatus {
                 Ok(InstallStatus::Failed)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskLog;
+
+    #[test]
+    fn should_deserialize_legacy_task_log_without_build_timestamp() {
+        let content = "dadk_config_timestamp = \"2026-02-09T19:42:17.464516620Z\"\n";
+        let task_log: TaskLog = toml::from_str(content).expect("legacy task_log must be readable");
+        assert!(task_log.build_time().is_none());
     }
 }

--- a/dadk/Cargo.toml
+++ b/dadk/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "xuzihao <xuzihao@DragonOS.org>"
 ]
 
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "DragonOS Application Development Kit\nDragonOS应用开发工具"
 license = "GPL-2.0-only"
@@ -33,8 +33,8 @@ insiders = []
 anyhow = { version = "1.0.100", features = ["std", "backtrace"] }
 clap = { version = "4.5.20", features = ["derive"] }
 crossbeam = "0.8.4"
-dadk-config = { version = "0.6.0", path = "../dadk-config" }
-dadk-user = { version = "0.6.0", path = "../dadk-user" }
+dadk-config = { version = "0.6.1", path = "../dadk-config" }
+dadk-user = { version = "0.6.1", path = "../dadk-user" }
 derive_builder = "0.20.0"
 env_logger = { workspace = true }
 humantime = "2.1.0"

--- a/docs/user-manual/quickstart.md
+++ b/docs/user-manual/quickstart.md
@@ -13,11 +13,11 @@ DADK是一个用于管理DragonOS的应用编译打包的工具。您可以通�
 
 
 ```
-MIN_DADK_VERSION = 0.6.0
+MIN_DADK_VERSION = 0.6.1
 ```
 
 ::: warning 注意版本兼容性
-请确保您使用的 dadk 版本与 DragonOS 当前分支要求一致（当前推荐 `v0.6.0`）。
+请确保您使用的 dadk 版本与 DragonOS 当前分支要求一致（当前推荐 `v0.6.1`）。
 :::
 
 您可以通过以下命令安装dadk:
@@ -25,9 +25,9 @@ MIN_DADK_VERSION = 0.6.0
 cargo install --git https://git.mirrors.dragonos.org.cn/DragonOS-Community/DADK.git --tag <版本号> --locked
 ```
 
-比如，对于0.6.0版本，您可以使用以下命令安装: `(注意版本号前面有个v)`
+比如，对于0.6.1版本，您可以使用以下命令安装: `(注意版本号前面有个v)`
 ```shell
-cargo install --git https://git.mirrors.dragonos.org.cn/DragonOS-Community/DADK.git --tag v0.6.0 --locked
+cargo install --git https://git.mirrors.dragonos.org.cn/DragonOS-Community/DADK.git --tag v0.6.1 --locked
 ```
 
 ## RootFS（ext4 + Docker base）


### PR DESCRIPTION
fix(cache): 改进任务日志读取的错误处理并添加兼容性测试
- 在`task_log`方法中，将直接使用`unwrap`改为使用`match`
进行错误处理，当读取或解析失败时记录警告并返回默认的`TaskLog`
- 在`TaskLog`结构体的`build_time`字段上添加`default`
属性，以支持反序列化旧版本中缺失该字段的任务日志
- 添加单元测试`should_deserialize_legacy_task_log_without_build_timestamp`
，确保能正确读取旧格式的任务日志
